### PR TITLE
Fixes for League Mastery API due to obsolete attributes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
 
 		<!-- Version metadata -->
 		<VersionSuffix>dev</VersionSuffix>
-		<VersionPrefix>0.2.1</VersionPrefix>
+		<VersionPrefix>0.3.0</VersionPrefix>
 		<Version Condition="'$(Version)' == ''">$(Version)</Version>
 		<Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
 		<Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>

--- a/craftersmine.Riot.Api.Account/craftersmine.Riot.Api.Account.csproj
+++ b/craftersmine.Riot.Api.Account/craftersmine.Riot.Api.Account.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot Account v1 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.ChampionRotations/craftersmine.Riot.Api.League.ChampionRotations.csproj
+++ b/craftersmine.Riot.Api.ChampionRotations/craftersmine.Riot.Api.League.ChampionRotations.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot League of Legends Champion rotations v4 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.Common/craftersmine.Riot.Api.Common.csproj
+++ b/craftersmine.Riot.Api.Common/craftersmine.Riot.Api.Common.csproj
@@ -3,10 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Common classes for craftesmine.Riot.Api libraries</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/craftersmine.Riot.Api.League.Challenges/craftersmine.Riot.Api.League.Challenges.csproj
+++ b/craftersmine.Riot.Api.League.Challenges/craftersmine.Riot.Api.League.Challenges.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot League of Legends Challenges v1 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.League.Clash/craftersmine.Riot.Api.League.Clash.csproj
+++ b/craftersmine.Riot.Api.League.Clash/craftersmine.Riot.Api.League.Clash.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot League of Legends Clash v1 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.League.Client.Replay/craftersmine.Riot.Api.League.Client.Replay.csproj
+++ b/craftersmine.Riot.Api.League.Client.Replay/craftersmine.Riot.Api.League.Client.Replay.csproj
@@ -2,7 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.League.Client/craftersmine.Riot.Api.League.Client.csproj
+++ b/craftersmine.Riot.Api.League.Client/craftersmine.Riot.Api.League.Client.csproj
@@ -1,9 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot League of Legends Client API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.League.Mastery/LeagueMasteryApiClient.cs
+++ b/craftersmine.Riot.Api.League.Mastery/LeagueMasteryApiClient.cs
@@ -27,6 +27,7 @@ namespace craftersmine.Riot.Api.League.Mastery
         /// <returns>Array of <see cref="LeagueChampionMastery"/> with all ever earned masteries for summoner</returns>
         /// <exception cref="ArgumentNullException">When summoner ID is null or empty</exception>
         /// <exception cref="craftersmine.Riot.Api.Common.Exceptions.RiotApiException">When Riot API request fails</exception>
+        [Obsolete("Endpoints by summonerID are deprecated and will be removed in January/2024. Use the equivalent by PUUID.", true)]
         public async Task<LeagueChampionMastery[]> GetMasteriesBySummonerId(RiotPlatform region, string summonerId)
         {
             if (string.IsNullOrWhiteSpace(summonerId))
@@ -34,6 +35,26 @@ namespace craftersmine.Riot.Api.League.Mastery
 
             string endpoint = UriUtils.GetAddress(region,
                 UriUtils.JoinEndpoints(ApiEndpointRoot, "champion-masteries/by-summoner", summonerId));
+
+            LeagueChampionMastery[] masteries = await Client.GetAsync<LeagueChampionMastery[]>(endpoint, null);
+            return masteries;
+        }
+
+        /// <summary>
+        /// Gets all champion masteries existing on champions for League of Legends summoner by Riot Games PUUID
+        /// </summary>
+        /// <param name="region">League of Legends server region</param>
+        /// <param name="puuid">Riot Games PUUID</param>
+        /// <returns>Array of <see cref="LeagueChampionMastery"/> with all ever earned masteries for summoner</returns>
+        /// <exception cref="ArgumentNullException">When PUUID is null or empty</exception>
+        /// <exception cref="craftersmine.Riot.Api.Common.Exceptions.RiotApiException">When Riot API request fails</exception>
+        public async Task<LeagueChampionMastery[]> GetMasteriesByPuuid(RiotPlatform region, string puuid)
+        {
+            if (string.IsNullOrWhiteSpace(puuid))
+                throw new ArgumentNullException(nameof(puuid));
+
+            string endpoint = UriUtils.GetAddress(region,
+                UriUtils.JoinEndpoints(ApiEndpointRoot, "champion-masteries/by-puuid", puuid));
 
             LeagueChampionMastery[] masteries = await Client.GetAsync<LeagueChampionMastery[]>(endpoint, null);
             return masteries;
@@ -49,6 +70,7 @@ namespace craftersmine.Riot.Api.League.Mastery
         /// <exception cref="ArgumentOutOfRangeException">When champion ID is less than 1</exception>
         /// <exception cref="ArgumentNullException">When summoner ID is null or empty</exception>
         /// <exception cref="craftersmine.Riot.Api.Common.Exceptions.RiotApiException">When Riot API request fails</exception>
+        [Obsolete("Endpoints by summonerID are deprecated and will be removed in January/2024. Use the equivalent by PUUID.", true)]
         public async Task<LeagueChampionMastery> GetMasteryForChampionBySummonerId(RiotPlatform region, int championId,
             string summonerId)
         {
@@ -67,6 +89,33 @@ namespace craftersmine.Riot.Api.League.Mastery
         }
 
         /// <summary>
+        /// Gets a mastery information for specified League of Legends champion for specified summoner by summoner ID
+        /// </summary>
+        /// <param name="region">League of Legends server region</param>
+        /// <param name="championId">League of Legends champion ID</param>
+        /// <param name="puuid">Riot Games PUUID</param>
+        /// <returns><see cref="LeagueChampionMastery"/> for specified champion on specified summoner</returns>
+        /// <exception cref="ArgumentOutOfRangeException">When champion ID is less than 1</exception>
+        /// <exception cref="ArgumentNullException">When PUUID is null or empty</exception>
+        /// <exception cref="craftersmine.Riot.Api.Common.Exceptions.RiotApiException">When Riot API request fails</exception>
+        public async Task<LeagueChampionMastery> GetMasteryForChampionByPuuid(RiotPlatform region, int championId,
+            string puuid)
+        {
+            if (championId < 1)
+                throw new ArgumentOutOfRangeException(nameof(championId), "Champion ID cannot be less than 1");
+
+            if (string.IsNullOrWhiteSpace(puuid))
+                throw new ArgumentNullException(nameof(puuid));
+
+            string endpoint = UriUtils.GetAddress(region,
+                UriUtils.JoinEndpoints(ApiEndpointRoot, "champion-masteries/by-puuid/", puuid, "/by-champion/",
+                    championId.ToString()));
+
+            LeagueChampionMastery mastery = await Client.GetAsync<LeagueChampionMastery>(endpoint, null);
+            return mastery;
+        }
+
+        /// <summary>
         /// Gets a specified top champion masteries for specified summoner by summoner ID
         /// </summary>
         /// <param name="region">League of Legends server region</param>
@@ -76,6 +125,7 @@ namespace craftersmine.Riot.Api.League.Mastery
         /// <exception cref="ArgumentOutOfRangeException">When top count is less than 1</exception>
         /// <exception cref="ArgumentNullException">When summoner ID is null or empty</exception>
         /// <exception cref="craftersmine.Riot.Api.Common.Exceptions.RiotApiException">When Riot API request fails</exception>
+        [Obsolete("Endpoints by summonerID are deprecated and will be removed in January/2024. Use the equivalent by PUUID.", true)]
         public async Task<LeagueChampionMastery[]> GetTopMasteriesBySummonerId(RiotPlatform region, string summonerId,
             int topEntriesCount)
         {
@@ -94,6 +144,33 @@ namespace craftersmine.Riot.Api.League.Mastery
         }
 
         /// <summary>
+        /// Gets a specified top champion masteries for specified summoner by summoner ID
+        /// </summary>
+        /// <param name="region">League of Legends server region</param>
+        /// <param name="puuid">Riot Games PUUID</param>
+        /// <param name="topEntriesCount">Count of mastery entries for top</param>
+        /// <returns>An array of top count of <see cref="LeagueChampionMastery"/></returns>
+        /// <exception cref="ArgumentOutOfRangeException">When top count is less than 1</exception>
+        /// <exception cref="ArgumentNullException">When PUUID is null or empty</exception>
+        /// <exception cref="craftersmine.Riot.Api.Common.Exceptions.RiotApiException">When Riot API request fails</exception>
+        public async Task<LeagueChampionMastery[]> GetTopMasteriesByPuuid(RiotPlatform region, string puuid,
+            int topEntriesCount)
+        {
+            if (topEntriesCount < 1)
+                throw new ArgumentOutOfRangeException(nameof(topEntriesCount),
+                    "Top entries count cannot be less than 1");
+            if (string.IsNullOrWhiteSpace(puuid))
+                throw new ArgumentNullException(nameof(puuid));
+
+            string endpoint = UriUtils.GetAddress(region,
+                UriUtils.JoinEndpoints(ApiEndpointRoot, "champion-masteries/by-puuid/", puuid, "/top"));
+
+            LeagueChampionMastery[] topMasteries = await Client.GetAsync<LeagueChampionMastery[]>(endpoint,
+                new Dictionary<string, object>() {{"count", topEntriesCount}});
+            return topMasteries;
+        }
+
+        /// <summary>
         /// Gets a specified top 3 champion masteries for specified summoner by summoner ID
         /// </summary>
         /// <param name="region">League of Legends server region</param>
@@ -101,10 +178,25 @@ namespace craftersmine.Riot.Api.League.Mastery
         /// <returns>An array of top count of <see cref="LeagueChampionMastery"/></returns>
         /// <exception cref="ArgumentNullException">When summoner ID is null or empty</exception>
         /// <exception cref="craftersmine.Riot.Api.Common.Exceptions.RiotApiException">When Riot API request fails</exception>
+        [Obsolete("Endpoints by summonerID are deprecated and will be removed in January/2024. Use the equivalent by PUUID.", true)]
         public async Task<LeagueChampionMastery[]> GetTopThreeMasteriesBySummonerId(RiotPlatform region,
             string summonerId)
         {
             return await GetTopMasteriesBySummonerId(region, summonerId, 3);
+        }
+
+        /// <summary>
+        /// Gets a specified top 3 champion masteries for specified summoner by summoner ID
+        /// </summary>
+        /// <param name="region">League of Legends server region</param>
+        /// <param name="puuid">Riot Games PUUID</param>
+        /// <returns>An array of top count of <see cref="LeagueChampionMastery"/></returns>
+        /// <exception cref="ArgumentNullException">When Riot Games PUUID is null or empty</exception>
+        /// <exception cref="craftersmine.Riot.Api.Common.Exceptions.RiotApiException">When Riot API request fails</exception>
+        public async Task<LeagueChampionMastery[]> GetTopThreeMasteriesByPuuid(RiotPlatform region,
+            string puuid)
+        {
+            return await GetTopMasteriesByPuuid(region, puuid, 3);
         }
 
         /// <summary>
@@ -115,6 +207,7 @@ namespace craftersmine.Riot.Api.League.Mastery
         /// <returns><see cref="int"/> of total earned masteries on all champions</returns>
         /// <exception cref="ArgumentNullException">When summoner ID is null or empty</exception>
         /// <exception cref="craftersmine.Riot.Api.Common.Exceptions.RiotApiException">When Riot API request fails</exception>
+        [Obsolete("Endpoints by summonerID are deprecated and will be removed in January/2024. Use the equivalent by PUUID.", true)]
         public async Task<int> GetTotalMasteriesBySummonerId(RiotPlatform region, string summonerId)
         {
             if (string.IsNullOrWhiteSpace(summonerId))
@@ -122,6 +215,26 @@ namespace craftersmine.Riot.Api.League.Mastery
 
             string endpoint = UriUtils.GetAddress(region,
                 UriUtils.JoinEndpoints(ApiEndpointRoot, "scores/by-summoner", summonerId));
+
+            int totalMasteries = await Client.GetAsync<int>(endpoint, null);
+            return totalMasteries;
+        }
+        
+        /// <summary>
+        /// Gets total number of masteries on all champions for specified summoner by summoner ID
+        /// </summary>
+        /// <param name="region">League of Legends server region</param>
+        /// <param name="puuid">Riot Games PUUID</param>
+        /// <returns><see cref="int"/> of total earned masteries on all champions</returns>
+        /// <exception cref="ArgumentNullException">When PUUID is null or empty</exception>
+        /// <exception cref="craftersmine.Riot.Api.Common.Exceptions.RiotApiException">When Riot API request fails</exception>
+        public async Task<int> GetTotalMasteriesByPuuid(RiotPlatform region, string puuid)
+        {
+            if (string.IsNullOrWhiteSpace(puuid))
+                throw new ArgumentNullException(nameof(puuid));
+
+            string endpoint = UriUtils.GetAddress(region,
+                UriUtils.JoinEndpoints(ApiEndpointRoot, "scores/by-puuid", puuid));
 
             int totalMasteries = await Client.GetAsync<int>(endpoint, null);
             return totalMasteries;

--- a/craftersmine.Riot.Api.League.Mastery/craftersmine.Riot.Api.League.Mastery.csproj
+++ b/craftersmine.Riot.Api.League.Mastery/craftersmine.Riot.Api.League.Mastery.csproj
@@ -1,9 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot League of Legends Champion Mastery v4 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.League.Matches.Timeline/craftersmine.Riot.Api.League.Matches.Timeline.csproj
+++ b/craftersmine.Riot.Api.League.Matches.Timeline/craftersmine.Riot.Api.League.Matches.Timeline.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot League of Legends Match v5 Timeline API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.League.Matches\craftersmine.Riot.Api.League.Matches.csproj" />

--- a/craftersmine.Riot.Api.League.Matches/craftersmine.Riot.Api.League.Matches.csproj
+++ b/craftersmine.Riot.Api.League.Matches/craftersmine.Riot.Api.League.Matches.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot League of Legends Match v5 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.League.Spectator/craftersmine.Riot.Api.League.Spectator.csproj
+++ b/craftersmine.Riot.Api.League.Spectator/craftersmine.Riot.Api.League.Spectator.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot League of Legends Spectator v4 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.League.Summoner/craftersmine.Riot.Api.League.Summoner.csproj
+++ b/craftersmine.Riot.Api.League.Summoner/craftersmine.Riot.Api.League.Summoner.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot League of Legends Summoner v4 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.League.SummonerLeagues/craftersmine.Riot.Api.League.SummonerLeagues.csproj
+++ b/craftersmine.Riot.Api.League.SummonerLeagues/craftersmine.Riot.Api.League.SummonerLeagues.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot League of Legends Summoner Ranked Leagues v4 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.League.Summoner\craftersmine.Riot.Api.League.Summoner.csproj" />

--- a/craftersmine.Riot.Api.League.Tournament/craftersmine.Riot.Api.League.Tournament.csproj
+++ b/craftersmine.Riot.Api.League.Tournament/craftersmine.Riot.Api.League.Tournament.csproj
@@ -1,9 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot League of Legends Tournaments v4 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.Runeterra.Match/craftersmine.Riot.Api.Runeterra.Matches.csproj
+++ b/craftersmine.Riot.Api.Runeterra.Match/craftersmine.Riot.Api.Runeterra.Matches.csproj
@@ -1,9 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot Legends of Runeterra Match v1 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.Runeterra.Ranked/craftersmine.Riot.Api.Runeterra.Ranked.csproj
+++ b/craftersmine.Riot.Api.Runeterra.Ranked/craftersmine.Riot.Api.Runeterra.Ranked.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot Legends of Runeterra Ranked v1 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.Status/craftersmine.Riot.Api.Status.csproj
+++ b/craftersmine.Riot.Api.Status/craftersmine.Riot.Api.Status.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot Services Status API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.Tests/League/LeagueSummonerApiClientTests.cs
+++ b/craftersmine.Riot.Api.Tests/League/LeagueSummonerApiClientTests.cs
@@ -15,6 +15,7 @@ namespace craftersmine.Riot.Api.Tests.League
         public const string MySummonerNameRu = "craftersmine";
         public const string MyAccountId = "1Qr4Eh3voM158K6jQOrEkl02Tk20MY9HI3NLq6phi4NG7sjvo1OeYhzy";
         public const string MySummonerId = "PtRpTVHs2N12hcdRB5OgxNcs2y4wAK7yg4K38y8028YwBGw";
+        public const string MyPuuid = "XRWOl9NePvqBbDsCBQKMgks13Cyc5KO1N-ZCPE0xr8Yvt58H7JjiWx_jlkF4VSYc31kBYfoKZtSNhA";
 
         public LeagueSummonerApiClient? Client { get; set; }
         public string? ApiKey { get; set; }

--- a/craftersmine.Riot.Api.Tests/League/MasteryApiClientTests.cs
+++ b/craftersmine.Riot.Api.Tests/League/MasteryApiClientTests.cs
@@ -15,7 +15,7 @@ namespace craftersmine.Riot.Api.Tests.League
     {
         public const int OrnnChampionId = 516;
         public const int VolibearChampionId = 106;
-        public const int GnarChampionId = 150;
+        public const int ZiggsChampionId = 115;
         public const bool EnableExperimental = false;
 
         public LeagueMasteryApiClient? Client { get; set; }
@@ -40,11 +40,11 @@ namespace craftersmine.Riot.Api.Tests.League
         }
 
         [TestMethod]
-        public async Task GetMasteriesBySummonerIdTests()
+        public async Task GetMasteriesByPuuidTests()
         {
             Assert.IsNotNull(Client, "Client is not initialized");
             LeagueChampionMastery[] masteries =
-                await Client.GetMasteriesBySummonerId(RiotPlatform.Russia, LeagueSummonerApiClientTests.MySummonerId);
+                await Client.GetMasteriesByPuuid(RiotPlatform.Russia, LeagueSummonerApiClientTests.MyPuuid);
             Assert.IsTrue(masteries.Any(), "No masteries returned");
             LeagueChampionMastery? ornnMastery = masteries.FirstOrDefault(m => m.ChampionId == OrnnChampionId);
             Assert.IsNotNull(ornnMastery,
@@ -55,12 +55,12 @@ namespace craftersmine.Riot.Api.Tests.League
         }
 
         [TestMethod]
-        public async Task GetMasteryForChampionBySummonerIdTests()
+        public async Task GetMasteryForChampionByPuuidTests()
         {
             Assert.IsNotNull(Client, "Client is not initialized");
             LeagueChampionMastery ornnMastery =
-                await Client.GetMasteryForChampionBySummonerId(RiotPlatform.Russia, OrnnChampionId,
-                    LeagueSummonerApiClientTests.MySummonerId);
+                await Client.GetMasteryForChampionByPuuid(RiotPlatform.Russia, OrnnChampionId,
+                    LeagueSummonerApiClientTests.MyPuuid);
             Assert.IsNotNull(ornnMastery,
                 "No mastery for Ornn in my champion pool (almost a 1m points and mastery 7, something wrong)");
             Assert.IsTrue(ornnMastery.MasteryLevel == 7,
@@ -73,18 +73,18 @@ namespace craftersmine.Riot.Api.Tests.League
         {
             Assert.IsNotNull(Client, "Client is not initialized");
             LeagueChampionMastery[] topMasteries =
-                await Client.GetTopThreeMasteriesBySummonerId(RiotPlatform.Russia,
-                    LeagueSummonerApiClientTests.MySummonerId);
+                await Client.GetTopThreeMasteriesByPuuid(RiotPlatform.Russia,
+                    LeagueSummonerApiClientTests.MyPuuid);
             Assert.IsTrue(topMasteries.Any(), "No masteries returned");
             LeagueChampionMastery? ornnMastery = topMasteries.FirstOrDefault(m => m.ChampionId == OrnnChampionId);
             LeagueChampionMastery? voliMastery = topMasteries.FirstOrDefault(m => m.ChampionId == VolibearChampionId);
-            LeagueChampionMastery? gnarMastery = topMasteries.FirstOrDefault(m => m.ChampionId == GnarChampionId);
+            LeagueChampionMastery? gnarMastery = topMasteries.FirstOrDefault(m => m.ChampionId == ZiggsChampionId);
             Assert.IsNotNull(ornnMastery,
                 "No mastery for Ornn in my champion pool (almost a 1m points and mastery 7, something wrong)");
             Assert.IsNotNull(voliMastery,
                 "No mastery for Volibear in my champion pool (over 150k points and mastery 7, something wrong)");
             Assert.IsNotNull(gnarMastery,
-                "No mastery for Gnar in my champion pool (over 35k points and mastery 5, something wrong)");
+                "No mastery for Ziggs in my champion pool (over 35k points and mastery 5, something wrong)");
             Assert.IsTrue(ornnMastery.MasteryLevel == 7,
                 "Got 7th mastery on Ornn, but it reported " + ornnMastery.MasteryLevel);
             Assert.IsTrue(ornnMastery.MasteryPoints > 950000, "It is definitely over 950k on Ornn");
@@ -97,12 +97,12 @@ namespace craftersmine.Riot.Api.Tests.League
         }
 
         [TestMethod]
-        public async Task GetTotalMasteriesBySummonerIdTests()
+        public async Task GetTotalMasteriesByPuuidTests()
         {
             Assert.IsNotNull(Client, "Client is not initialized");
             int totalMasteries =
-                await Client.GetTotalMasteriesBySummonerId(RiotPlatform.Russia,
-                    LeagueSummonerApiClientTests.MySummonerId);
+                await Client.GetTotalMasteriesByPuuid(RiotPlatform.Russia,
+                    LeagueSummonerApiClientTests.MyPuuid);
         }
     }
 }

--- a/craftersmine.Riot.Api.Tft.Leagues/craftersmine.Riot.Api.Tft.Leagues.csproj
+++ b/craftersmine.Riot.Api.Tft.Leagues/craftersmine.Riot.Api.Tft.Leagues.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot Teamfight Tactics Leagues v1 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.League.SummonerLeagues\craftersmine.Riot.Api.League.SummonerLeagues.csproj" />

--- a/craftersmine.Riot.Api.Tft.Matches/craftersmine.Riot.Api.Tft.Matches.csproj
+++ b/craftersmine.Riot.Api.Tft.Matches/craftersmine.Riot.Api.Tft.Matches.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot Teamfight Tactics Match v1 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.Tft.Summoner/craftersmine.Riot.Api.Tft.Summoner.csproj
+++ b/craftersmine.Riot.Api.Tft.Summoner/craftersmine.Riot.Api.Tft.Summoner.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot Teamfight Tactics Summoner v1 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.League.Summoner\craftersmine.Riot.Api.League.Summoner.csproj" />

--- a/craftersmine.Riot.Api.Valorant.Content/craftersmine.Riot.Api.Valorant.Content.csproj
+++ b/craftersmine.Riot.Api.Valorant.Content/craftersmine.Riot.Api.Valorant.Content.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot Valorant Content v1 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />

--- a/craftersmine.Riot.Api.Valorant.Ranked/craftersmine.Riot.Api.Valorant.Ranked.csproj
+++ b/craftersmine.Riot.Api.Valorant.Ranked/craftersmine.Riot.Api.Valorant.Ranked.csproj
@@ -3,7 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <Description>Riot Valorant Ranked v1 API wrapper for .NET</Description>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\craftersmine.Riot.Api.Common\craftersmine.Riot.Api.Common.csproj" />


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes issues with requesting Mastery API due to Riot marked Mastery endpoints with summoner-id parameters as obsolete too early instead of January 2024

Any other comments?
-------------------
The old by summoner id methods marked as obsolete and will show an error when compiling

Where has this been tested?
---------------------------
**Operating System:** Windows 10 x64 23H2 Release Channel

**Platform:** .NET Standard 2.0

**Library version:** 0.2.1-dev
